### PR TITLE
added comentation to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,16 @@ tasks = [{'module_name': 'kb_Bowtie2',
          ...
          ]
 
-# NOTE: modules called by kbparallel (i.e. kb_Bowtie2) have to be registered in appdev as 'release', 'beta', or 'dev'.
+# NOTE: modules called by kbparallel (i.e. kb_Bowtie2) have to be registered in appdev as 'release', 
+# 'beta', or 'dev'.
 
 
 # configure how tasks are run
 # ---------------------------
 # you can set how many concurrent jobs you want running on the local 
-# machine, 1 in this case, and how many nodes you want running in parallel, 2.
-# For example, in this case, if you have 5 tasks, 3 will get run in 
-# serial on the local machine and 2 on separate nodes. 
+# machine, and how many nodes you want running in parallel.
+# For example, in this case, if you have 5 tasks, 2 will be submitted to 2 njsw nodes and the
+# remaining 3 will get run in serial on the local machine. 
 
 batch_run_params = {'tasks': tasks,
                     'runner': 'parallel', # parallel | local_parallel | local_serial

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # KBParallel
 ---
 A low level module for managing simple bulk execution in KBase.
@@ -23,11 +22,18 @@ kb-sdk install KBParallel
 
 
 ## Example Usage
+Please read all comments since a lot of key info is there.  
+
 ```
 # invoke from an App like any other KBase SDK function call
 parallel_runner = KBParallel(self.callback_url)
 
 # build a list of tasks
+# ---------------------
+# The parameters `'parameters': { ... }` are the parameters that are sent to 
+# `align_reads_to_assembly_app`.  For instance, if you are trying to align 
+# multiple fastq files in parallel, then the parameters will include 
+# the paths to the fastqs.
 tasks = [{'module_name': 'kb_Bowtie2',
          'function_name': 'align_reads_to_assembly_app',
          'version': 'dev',
@@ -36,7 +42,16 @@ tasks = [{'module_name': 'kb_Bowtie2',
          ...
          ]
 
+# NOTE: modules called by kbparallel (i.e. kb_Bowtie2) have to be registered in appdev as 'release', 'beta', or 'dev'.
+
+
 # configure how tasks are run
+# ---------------------------
+# you can set how many concurrent jobs you want running on the local 
+# machine, 1 in this case, and how many nodes you want running in parallel, 2.
+# For example, in this case, if you have 5 tasks, 3 will get run in 
+# serial on the local machine and 2 on separate nodes. 
+
 batch_run_params = {'tasks': tasks,
                     'runner': 'parallel', # parallel | local_parallel | local_serial
                     'concurrent_local_tasks': 1,
@@ -48,7 +63,15 @@ batch_run_params = {'tasks': tasks,
 results = parallel_runner.run_batch(batch_run_params)
 ```
 
+
 ```
+# results data structure
+# ----------------------
+# The results of the function being called by kbparallel 
+# (align_reads_to_assembly_app), must be returned or it will not be accessable; 
+# for instance, if align_reads_to_assembly_app creates a new alignment 
+# file, the path to this file must be returned in the output dictionary. 
+
 results =>
 {u'results': [{u'is_error': 0,
                u'result_package': {u'error': None,
@@ -64,3 +87,16 @@ results =>
               ]
 
 ```
+
+### Some Examples
+1) for a simple hello world example running 3 tasks that just create a .txt file using 1 local & 2 njsw nodes:  
+
+To try it, search for "kbparallel example" in 'dev'.  https://gitlab.com/jfroula/kbparallel_example.git
+
+2) for an example that actually does something, see:  
+
+search for bowtie2 or "Align Reads using Bowtie2 v2.3.2".  https://github.com/kbaseapps/kb_Bowtie2. 
+
+This example is tricky because it calls the same function ("align" in Bowtie2Aligner.py) twice, once to set up the parallel tasks (runs this section first `if input_info['run_mode'] == 'sample_set'`)  
+
+and then again to run each task (runs this section second `if input_info['run_mode'] == 'single_library':`).  This section actually does the work by calling single\_reads\_lib\_run.  

--- a/README.md
+++ b/README.md
@@ -93,12 +93,12 @@ results =>
 I.
 For a simple hello world example that runs 3 tasks in parallel; each job creates a .txt file.  The jobs are run on 1 local & 2 njsw nodes:  
 
-to try it, search for "kbparallel example" in 'dev'.  https://gitlab.com/jfroula/kbparallel_example.git
+to try it, search for "kbparallel example" in 'dev'.  (also see https://gitlab.com/jfroula/kbparallel_example.git) .  
 
 II.
 For an example that actually does something:  
 
-search for bowtie2 or "Align Reads using Bowtie2 v2.3.2".  https://github.com/kbaseapps/kb_Bowtie2. 
+search for bowtie2 or "Align Reads using Bowtie2 v2.3.2".  (also see https://github.com/kbaseapps/kb_Bowtie2) .  
 
 This example is tricky because it calls the same function ("align" in Bowtie2Aligner.py) twice, once to set up the parallel tasks (runs this section first `if input_info['run_mode'] == 'sample_set'`)  
 

--- a/README.md
+++ b/README.md
@@ -90,11 +90,13 @@ results =>
 ```
 
 ### Some Examples
-1) for a simple hello world example running 3 tasks that just create a .txt file using 1 local & 2 njsw nodes:  
+I.
+for a simple hello world example running 3 tasks that just create a .txt file using 1 local & 2 njsw nodes:  
 
-To try it, search for "kbparallel example" in 'dev'.  https://gitlab.com/jfroula/kbparallel_example.git
+to try it, search for "kbparallel example" in 'dev'.  https://gitlab.com/jfroula/kbparallel_example.git
 
-2) for an example that actually does something, see:  
+II.
+for an example that actually does something:  
 
 search for bowtie2 or "Align Reads using Bowtie2 v2.3.2".  https://github.com/kbaseapps/kb_Bowtie2. 
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ parallel_runner = KBParallel(self.callback_url)
 
 # build a list of tasks
 # ---------------------
-# The parameters `'parameters': { ... }` are the parameters that are sent to 
-# `align_reads_to_assembly_app`.  For instance, if you are trying to align 
+# The parameters 'parameters': { ... } are the parameters that are sent to 
+# align_reads_to_assembly_app.  For instance, if you are trying to align 
 # multiple fastq files in parallel, then the parameters will include 
 # the paths to the fastqs.
 tasks = [{'module_name': 'kb_Bowtie2',

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ parallel_runner = KBParallel(self.callback_url)
 
 # build a list of tasks
 # ---------------------
-# The parameters 'parameters': { ... } are the parameters that are sent to 
+# The parameters ('parameters': { ... }) are the parameters that are sent to 
 # align_reads_to_assembly_app.  For instance, if you are trying to align 
 # multiple fastq files in parallel, then the parameters will include 
 # the paths to the fastqs.
@@ -93,12 +93,12 @@ results =>
 I.
 For a simple hello world example that runs 3 tasks in parallel; each job creates a .txt file.  The jobs are run on 1 local & 2 njsw nodes:  
 
-to try it, search for "kbparallel example" in 'dev'.  (also see https://gitlab.com/jfroula/kbparallel_example.git) .  
+to try it, search for __kbparallel example__ in 'dev'.  (also see https://gitlab.com/jfroula/kbparallel_example.git) .  
 
 II.
 For an example that actually does something:  
 
-search for bowtie2 or "Align Reads using Bowtie2 v2.3.2".  (also see https://github.com/kbaseapps/kb_Bowtie2) .  
+search for __bowtie2__ or __Align Reads using Bowtie2 v2.3.2__.  (also see https://github.com/kbaseapps/kb_Bowtie2) .  
 
 This example is tricky because it calls the same function ("align" in Bowtie2Aligner.py) twice, once to set up the parallel tasks (runs this section first `if input_info['run_mode'] == 'sample_set'`)  
 

--- a/README.md
+++ b/README.md
@@ -91,12 +91,12 @@ results =>
 
 ### Some Examples
 I.
-for a simple hello world example running 3 tasks that just create a .txt file using 1 local & 2 njsw nodes:  
+For a simple hello world example that runs 3 tasks in parallel; each job creates a .txt file.  The jobs are run on 1 local & 2 njsw nodes:  
 
 to try it, search for "kbparallel example" in 'dev'.  https://gitlab.com/jfroula/kbparallel_example.git
 
 II.
-for an example that actually does something:  
+For an example that actually does something:  
 
 search for bowtie2 or "Align Reads using Bowtie2 v2.3.2".  https://github.com/kbaseapps/kb_Bowtie2. 
 


### PR DESCRIPTION
I added alot of comentation to the example code and I added two links to working examples on the narrative.  "kbparallel example" exists on 'dev' only.