### PR TITLE
Develop -> Master

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
-# 0.4.9
+# 0.4.9.2
 * Various bug fixes with return of results package
+* Version bump to enable re-release on ci
 
 # 0.4.6
 * Changed kbparallels to use EE2

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    0.4.91
+    0.4.92
 
 owners:
     [mccorkle, wjriehl, bsadkhin]


### PR DESCRIPTION
* The reason the Release Notes was not updated before was due to testing out KBParallels on CI. It was an artifact of that, and was never released to production, so bug fixes are not really a release note
* Current release notes are up to date, nothing to add